### PR TITLE
Fixed issue where script throws error if first caption is at time 0

### DIFF
--- a/sample6.xml
+++ b/sample6.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<tt xmlns:tt="http://www.w3.org/2006/10/ttaf1" xmlns:ttm="http://www.w3.org/2006/10/ttaf1#metadata" xmlns:ttp="http://www.w3.org/2006/10/ttaf1#parameter" xmlns:tts="http://www.w3.org/2006/10/ttaf1#styling" ttp:tickRate="10000000" ttp:timeBase="media" xmlns="http://www.w3.org/2006/10/ttaf1">
+<head use="dfxp-ls-sdh">
+<ttp:profile xmlns:ttp="http://www.w3.org/2006/10/ttaf1"/>
+</head>
+<body>
+<div xml:space="preserve">
+<p begin="0t" end="59989929t" xml:id="subtitle0">[upbeat music]</p>
+<p begin="326986660t" end="337326990t" xml:id="subtitle1">All right, Jim,</p>
+<p begin="337657320t" end="362321960t" xml:id="subtitle2">your quarterlies<br/>look very good.</p>
+<p begin="362652290t" end="383663280t" xml:id="subtitle3">How are things going<br/>at the library?</p>
+<p begin="383993610t" end="408658250t" xml:id="subtitle4">Oh, I told you.<br/>I couldn't close it, so...</p>
+<p begin="408988580t" end="443322879t" xml:id="subtitle5">So you've come<br/>to the master for guidance?</p>
+</div>
+</body>
+</tt>

--- a/sample6.xml.srt
+++ b/sample6.xml.srt
@@ -1,0 +1,27 @@
+1
+0:0:0,0 --> 00:00:05,998
+[upbeat music]
+
+2
+00:00:32,698 --> 00:00:33,732
+All right, Jim,
+
+3
+00:00:33,765 --> 00:00:36,232
+your quarterlies
+look very good.
+
+4
+00:00:36,265 --> 00:00:38,366
+How are things going
+at the library?
+
+5
+00:00:38,399 --> 00:00:40,865
+Oh, I told you.
+I couldn't close it, so...
+
+6
+00:00:40,898 --> 00:00:44,332
+So you've come
+to the master for guidance?

--- a/to_srt.py
+++ b/to_srt.py
@@ -10,6 +10,8 @@ def leading_zeros(value, digits=2):
 
 
 def convert_time(raw_time):
+    if int(raw_time) == 0:
+        return "{}:{}:{},{}".format(0,0,0,0)
     ms = leading_zeros(int(raw_time[:-4]) % 1000, 3)
     # only interested in milliseconds, let's drop the additional digits
     time_in_seconds = int(raw_time[:-7])


### PR DESCRIPTION
Error was the following:

Traceback (most recent call last):
  File "to_srt.py", line 97, in <module>
    main()
  File "to_srt.py", line 94, in main
    f.write(to_srt(text))
  File "to_srt.py", line 69, in to_srt
    append_subs(prev_time["start"], prev_time["end"], prev_content, fmt_t)
  File "to_srt.py", line 25, in append_subs
    "start_time": convert_time(start) if format_time else start,
  File "to_srt.py", line 13, in convert_time
    ms = leading_zeros(int(raw_time[:-4]) % 1000, 3)
ValueError: invalid literal for int() with base 10: ''