### PR TITLE
Added support for italic and positions tags

### DIFF
--- a/to_srt.py
+++ b/to_srt.py
@@ -31,7 +31,10 @@ def to_srt(text):
             "end_time": convert_time(end) if format_time else end,
             "content": u"\n".join(prev_content),
         })
-
+    # displayAlign="before" means the current sub will be displayed on top, and not at bottom,
+    # so we check what's the xml:id associated to it to have an {\an8} position tag in the output file
+    check_display_align_before_re = re.compile(u'<region.*tts:displayAlign=\"before\".*xml:id=\"(.*)\"/>')
+    xml_id_display_align_before = re.search(check_display_align_before_re, text).group(1)    
     begin_re = re.compile(u"\s*<p begin=")
     sub_lines = (l for l in text.split("\n") if re.search(begin_re, l))
     subs = []
@@ -43,22 +46,36 @@ def to_srt(text):
     # this regex was sometimes too strict. I hope the new one is never too lax
     # content_re = re.compile(u'xml\:id\=\"subtitle[0-9]+\">(.*)</p>')
     content_re = re.compile(u'\">(.*)</p>')
-    alt_content_re = re.compile(u'<span style=\"[a-zA-Z0-9_]+\">(.*?)</span>')
+	# span tags are only used for italics, so we'll get rid of them
+	# and replace them by <i> and </i>, which is the standard for .srt files
+    # alt_content_re = re.compile(u'<span style=\"[a-zA-Z0-9_]+\">(.*?)</span>')
+    span_start_re = re.compile(u'(<span style=\"[a-zA-Z0-9_.]+\">)+')
+    span_end_re = re.compile(u'(</span>)+')
     br_re = re.compile(u'(<br\s*\/?>)+')
     fmt_t = True
     for s in sub_lines:
+        span_start_tags = re.search(span_start_re, s)
+        if span_start_tags:
+            s = u"<i>".join(s.split(span_start_tags.group()))
+        string_region_re = r'<p(.*region="' + xml_id_display_align_before + r'".*")>(.*)</p>'		
+        #s = re.sub(r'<p(.*region="region.top.centre".*")>(.*)</p>', r'<p\1>{\\an8}\2</p>', s)
+        s = re.sub(string_region_re, r'<p\1>{\\an8}\2</p>', s)
         content = []
-        alt_content = re.search(alt_content_re, s)
-        while (alt_content):  # background text may have additional styling.
+        # alt_content = re.search(alt_content_re, s)
+        # while (alt_content):  # background text may have additional styling.
             # background may also contain several `<span> </span>` groups
-            s = s.replace(alt_content.group(0), alt_content.group(1))
-            alt_content = re.search(alt_content_re, s)
+            # s = s.replace(alt_content.group(0), alt_content.group(1))
+            # alt_content = re.search(alt_content_re, s)
         content = re.search(content_re, s).group(1)
 
         br_tags = re.search(br_re, content)
         if br_tags:
             content = u"\n".join(content.split(br_tags.group()))
-
+		
+        span_end_tags = re.search(span_end_re, content)
+        if span_end_tags:
+           content = u"</i>".join(content.split(span_end_tags.group()))		
+		
         prev_start = prev_time["start"]
         start = re.search(start_re, s).group(1)
         end = re.search(end_re, s).group(1)
@@ -91,7 +108,7 @@ def main():
     parser.add_argument("-o", "--output", type=str, default=directory,
                         help=help_text.format("output", directory))
     a = parser.parse_args()
-    xmls = [x for x in os.listdir(a.input) if x[-4:] == ".xml"]
+    xmls = [x for x in os.listdir(a.input) if x[-4:] == ".txt"]
     for x in xmls:
         with codecs.open("{}/{}".format(a.input, x), 'rb', "utf-8") as f:
             text = f.read()

--- a/to_srt.py
+++ b/to_srt.py
@@ -108,7 +108,7 @@ def main():
     parser.add_argument("-o", "--output", type=str, default=directory,
                         help=help_text.format("output", directory))
     a = parser.parse_args()
-    xmls = [x for x in os.listdir(a.input) if x[-4:] == ".txt"]
+    xmls = [x for x in os.listdir(a.input) if x[-4:] == ".xml"]
     for x in xmls:
         with codecs.open("{}/{}".format(a.input, x), 'rb', "utf-8") as f:
             text = f.read()


### PR DESCRIPTION
I've replaced `<span>` tags by italics `<i>` tags, which are supported by a much wider range of players/decoders, including standalone ones. 
I've also quickly implemented the detection of `region="before"` so that subs that must be shown on top of the screen actually are so, and not at bottom where they would often be unreadable.